### PR TITLE
BUG: Adds safe fail for `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,5 @@ prepare:
 
 test:
 	@docker-compose up -d
-	@go test github.com/edwardsmatt/dynamocity -coverprofile=coverage.out
+	-go test -v github.com/edwardsmatt/dynamocity -coverprofile=coverage.out
 	@docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.5"
+version: "3.7"
 services:
   dynamodb:
     image: amazon/dynamodb-local


### PR DESCRIPTION
If `make test` executed failing tests, the dynamo docker container was
not stopped because the make file exited. This commit adds `-` to `go
test` to ignore failure exit codes from `go test` allowing the docker
container to shutdown gracefully