### PR TITLE
Adds MillisTime and SecondsTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,27 +10,24 @@ From the standard go library [time.RFC3339Nano](https://golang.org/pkg/time/#pkg
 
 Subsequently, because the existing [AWS Go SDK V2](https://github.com/aws/aws-sdk-go-v2/) uses `time.RFC3339Nano`, it is not suitable to use `time.Time` as a Dynamo DB Sort Key in a string attribute type.
 
-The reason why `dynamocity.Time` exists is because it provides an implementation `dynamodbattribute.Marshaler`, `dynamodbattribute.Unmarshaller` which enforces fixed nanosecond precision when marshalling for DynamoDB, making it safe for use as a DynamoDB range key.
-
+The reason why `dynamocity.NanoTime` exists is because it provides an implementation `dynamodbattribute.Marshaler`, `dynamodbattribute.Unmarshaller` which enforces fixed nanosecond precision when marshalling for DynamoDB, making it safe for use as a DynamoDB range key.
 
 ## Prerequisites
+
 * `docker-compose`
 * `go 1.12` (in alignment with the [AWS Go SDK V2](https://github.com/aws/aws-sdk-go-v2/))
 
 ## Getting Started
+
 Execute the following to provide an explanation of tasks that are commonly used for development.
 
-```bash
-make
-```
+    make help
 
 The output explains the common make targets and what they do:
-```
-Perform common development tasks
-Usage: make [TARGET]
-Targets:
-  clean			Clean removes the vendor directory, go.mod, and go.sum files
-  prepare		Sets up a go.mod, go.sum and downloads all vendor dependencies
-  test			Starts a dynamo local dynamo container and runs unit and integration tests
-```
 
+        Perform common development tasks
+        Usage: make [TARGET]
+        Targets:
+          clean     Clean removes the vendor directory, go.mod, and go.sum files
+          prepare   Sets up a go.mod, go.sum and downloads all vendor dependencies
+          test      Starts a dynamo local dynamo container and runs unit and integration tests

--- a/millis_time.go
+++ b/millis_time.go
@@ -1,0 +1,64 @@
+package dynamocity
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+// MillisTime represents a sortable strict RFC3339 Timestamp with fixed millisecond precision, making it string sortable.
+// MillisTime implements dynamodbattribute.Marshaler, dynamodbattribute.Unmarshaller
+// The standard library time.RFC3339Nano format removes trailing zeros from the seconds field
+// and thus may not sort correctly once formatted.
+type MillisTime time.Time
+
+// MarshalDynamoDBAttributeValue implements the dynamodb.Marshaler interface to marshal
+// a dynamocity.MillisTime into a DynamoDB AttributeValue string value with specific millisecond precision
+func (t MillisTime) MarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
+	rfcTime := time.Time(t).Format(StrictMillisFmt)
+	av.S = &rfcTime
+	return nil
+}
+
+// UnmarshalDynamoDBAttributeValue implements the dynamodb.Unmarshaler interface to unmarshal
+// a dynamodb.AttributeValue into a dynamocity.MillisTime. This unmarshal is flexible on millisecond precision
+func (t *MillisTime) UnmarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
+	timeString := *av.S
+	rfc339Time, err := time.Parse(FlexibleNanoFmt, timeString)
+	if err != nil {
+		return err
+	}
+	*t = MillisTime(rfc339Time)
+	return nil
+}
+
+// Time is a handler func to return an instance of dynamocity.MillisTime as time.Time
+func (t MillisTime) Time() time.Time {
+	return time.Time(t)
+}
+
+// String implements the fmt.Stringer interface to supply a native String representation for a value in RFC3339
+// Format with millisecond precision
+func (t MillisTime) String() string {
+	return t.Time().Format(StrictMillisFmt)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface to marshal RFC3339 timestamps with millisecond precision
+func (t *MillisTime) UnmarshalJSON(b []byte) error {
+	str, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	parsedTime, err := time.Parse(FlexibleNanoFmt, str)
+	if err != nil {
+		return err
+	}
+	*t = MillisTime(parsedTime)
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface to marshal RFC3339 timestamps with millisecond precision
+func (t MillisTime) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Quote(t.String())), nil
+}

--- a/nano_time.go
+++ b/nano_time.go
@@ -1,0 +1,64 @@
+package dynamocity
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+// NanoTime represents a sortable strict RFC3339 Timestamp with fixed nanosecond precision, making it string sortable.
+// NanoTime implements dynamodbattribute.Marshaler, dynamodbattribute.Unmarshaller
+// The standard library time.RFC3339Nano format removes trailing zeros from the seconds field
+// and thus may not sort correctly once formatted.
+type NanoTime time.Time
+
+// MarshalDynamoDBAttributeValue implements the dynamodb.Marshaler interface to marshal
+// a dynamocity.NanoTime into a DynamoDB AttributeValue string value with specific nanosecond precision
+func (t NanoTime) MarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
+	rfcTime := time.Time(t).Format(StrictNanoFmt)
+	av.S = &rfcTime
+	return nil
+}
+
+// UnmarshalDynamoDBAttributeValue implements the dynamodb.Unmarshaler interface to unmarshal
+// a dynamodb.AttributeValue into a dynamocity.NanoTime. This unmarshal is flexible on nanosecond precision
+func (t *NanoTime) UnmarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
+	timeString := *av.S
+	rfc339Time, err := time.Parse(FlexibleNanoFmt, timeString)
+	if err != nil {
+		return err
+	}
+	*t = NanoTime(rfc339Time)
+	return nil
+}
+
+// Time is a handler func to return an instance of dynamocity.NanoTime as time.Time
+func (t NanoTime) Time() time.Time {
+	return time.Time(t)
+}
+
+// String implements the fmt.Stringer interface to supply a native String representation for a value in RFC3339
+// Format with nanosecond precision
+func (t NanoTime) String() string {
+	return t.Time().Format(StrictNanoFmt)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface to marshal RFC3339 timestamps with nanosecond precision
+func (t *NanoTime) UnmarshalJSON(b []byte) error {
+	str, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	parsedTime, err := time.Parse(FlexibleNanoFmt, str)
+	if err != nil {
+		return err
+	}
+	*t = NanoTime(parsedTime)
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface to marshal RFC3339 timestamps with nanosecond precision
+func (t NanoTime) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Quote(t.String())), nil
+}

--- a/seconds_time.go
+++ b/seconds_time.go
@@ -1,0 +1,64 @@
+package dynamocity
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+// SecondsTime represents a sortable strict RFC3339 Timestamp with fixed second precision, making it string sortable.
+// SecondsTime implements dynamodbattribute.Marshaler, dynamodbattribute.Unmarshaller specifically for the time.RFC3339
+// format which does not permit fractional seconds; however, once this format is marshalled it may be sorted correctly in a
+// string value
+type SecondsTime time.Time
+
+// MarshalDynamoDBAttributeValue implements the dynamodb.Marshaler interface to marshal
+// a dynamocity.SecondsTime into a DynamoDB AttributeValue string value with specific second precision
+func (t SecondsTime) MarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
+	rfcTime := time.Time(t).Format(StrictSecondsFmt)
+	av.S = &rfcTime
+	return nil
+}
+
+// UnmarshalDynamoDBAttributeValue implements the dynamodb.Unmarshaler interface to unmarshal
+// a dynamodb.AttributeValue into a dynamocity.SecondsTime. This unmarshal is flexible on fractional second precision
+func (t *SecondsTime) UnmarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
+	timeString := *av.S
+	rfc339Time, err := time.Parse(FlexibleNanoFmt, timeString)
+	if err != nil {
+		return err
+	}
+	*t = SecondsTime(rfc339Time)
+	return nil
+}
+
+// Time is a handler func to return an instance of dynamocity.SecondsTime as time.Time
+func (t SecondsTime) Time() time.Time {
+	return time.Time(t)
+}
+
+// String implements the fmt.Stringer interface to supply a native String representation for a value in time.RFC3339
+// Format with second precision
+func (t SecondsTime) String() string {
+	return t.Time().Format(StrictMillisFmt)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface to marshal RFC3339 timestamps with second precision
+func (t *SecondsTime) UnmarshalJSON(b []byte) error {
+	str, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	parsedTime, err := time.Parse(FlexibleNanoFmt, str)
+	if err != nil {
+		return err
+	}
+	*t = SecondsTime(parsedTime)
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface to marshal RFC3339 timestamps with second precision
+func (t SecondsTime) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Quote(t.String())), nil
+}

--- a/time.go
+++ b/time.go
@@ -1,102 +1,60 @@
 package dynamocity
 
-import (
-	"strconv"
-	"time"
+import "time"
 
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-)
-
-// FlexibleNanoUnmarshallingFmt applies a backwards compatible nanosecond precision unmarshalling of a dynamocity.Time.
-// This ensures that timestamp strings marshalled with time.RFC3339Nano who may have had trailing zeros stripped
-// may be unmarshalled safely.
-const FlexibleNanoUnmarshallingFmt = time.RFC3339Nano
-
-// StrictNanoMarshallingFmt applies a strict nanosecond precision marshalling of a dynamocity.Time.
+// StrictNanoFmt applies a strict nanosecond precision marshalling of a dynamocity.NanoTime.
 // This ensures that trailing zeros are never stripped. The standard library time.RFC3339Nano format
-// removes trailing zeros beyond millisecond precision from the seconds field, and thus may not sort correctly once formatted.
-const StrictNanoMarshallingFmt = "2006-01-02T15:04:05.000000000Z07:00"
+// removes trailing zeros from the seconds field, and thus may not sort correctly once formatted.
+//
+// Unmarshalling using StrictNanoFmt will result in errors if the string does not strictly match the RFC3339 format with fixed
+// nanosecond precision. For example: `2006-01-02T15:04:05.000000000Z07:00`
+const StrictNanoFmt = "2006-01-02T15:04:05.000000000Z07:00"
 
-// Time represents a sortable strict RFC3339 Timestamp with fixed nanosecond precision, making it string sortable.
-// Time implements dynamodbattribute.Marshaler, dynamodbattribute.Unmarshaller
-// The standard library time.RFC3339Nano format removes trailing zeros beyond millis from the seconds field
-// and thus may not sort correctly once formatted.
-type Time time.Time
+// StrictMillisFmt applies a strict millisecond precision marshalling of a dynamocity.NanoTime.
+// This ensures that trailing zeros are never stripped. The standard library time.RFC3339Nano format
+// removes trailing zeros from the seconds field, and thus may not sort correctly once formatted.
+//
+// Unmarshalling using StrictMillisFmt will result in errors if the string does not strictly match the RFC3339 format with millisecond
+// precision. For example: `2006-01-02T15:04:05.000Z07:00`
+const StrictMillisFmt = "2006-01-02T15:04:05.000Z07:00"
 
-// MarshalDynamoDBAttributeValue implements the dynamodb.Marshaler interface to marshal
-// a dynamocity.Time into a DynamoDB AttributeValue string value with specific nanosecond precision
-func (t Time) MarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
-	rfcTime := time.Time(t).Format(StrictNanoMarshallingFmt)
-	av.S = &rfcTime
-	return nil
-}
+// StrictSecondsFmt is the standard library time.RFC3339, which applies a strict second precision marshalling and unmarshalling capability.
+//
+// Unmarshalling using StrictSecondsFmt will result in errors if the string does not strictly match the time.RFC3339 format.
+// For example: `2006-01-02T15:04:05Z07:00`
+const StrictSecondsFmt = time.RFC3339
 
-// UnmarshalDynamoDBAttributeValue implements the dynamodb.Unmarshaler interface to unmarshal
-// a dynamodb.AttributeValue into a dynamocity.Time. This unmarshal is flexible on nanosecond precision
-func (t *Time) UnmarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
-	timeString := *av.S
-	rfc339Time, err := time.Parse(FlexibleNanoUnmarshallingFmt, timeString)
-	if err != nil {
-		return err
-	}
-	*t = Time(rfc339Time)
-	return nil
-}
+// FlexibleNanoFmt is the standard library time.RFC3339Nano, which applies a flexible compatible nanosecond precision
+// marshalling and unmarshalling capability. However, when marshalling the standard library time.RFC3339Nano format removes trailing
+// zeros from the seconds field, and thus may not sort correctly once formatted.
+//
+// Therefore, this format is unsafe for marshalling to dynamo or JSON if the resultant value is expected to be sortable by string.
+const FlexibleNanoFmt = time.RFC3339Nano
 
-// Time is a handler func to return an instance of dynamocity.Time as time.Time
-func (t Time) Time() time.Time {
-	return time.Time(t)
-}
-
-// BetweenStartInc will return true if this dynamocity.Time is after or equal to the start and before the end
-func (t Time) BetweenStartInc(startInclusive, endExclusive Time) bool {
-	afterOrEqualToStart := t.Time().After(startInclusive.Time()) || t.Time().Equal(startInclusive.Time())
-	beforeEnd := t.Time().Before(endExclusive.Time())
+// BetweenStartInc will return true if this dynamocity.MillisTime is after or equal to the start and before the end
+func BetweenStartInc(t, startInclusive, endExclusive time.Time) bool {
+	afterOrEqualToStart := t.After(startInclusive) || t.Equal(startInclusive)
+	beforeEnd := t.Before(endExclusive)
 	return afterOrEqualToStart && beforeEnd
 }
 
-// BetweenEndInc will return true if this dynamocity.Time is after the start and before or equal to the end
-func (t Time) BetweenEndInc(startExclusive, endInclusive Time) bool {
-	afterStart := t.Time().After(startExclusive.Time())
-	beforeOrEqualToEnd := t.Time().Before(endInclusive.Time()) || t.Time().Equal(endInclusive.Time())
+// BetweenEndInc will return true if this dynamocity.MillisTime is after the start and before or equal to the end
+func BetweenEndInc(t, startExclusive, endInclusive time.Time) bool {
+	afterStart := t.After(startExclusive)
+	beforeOrEqualToEnd := t.Before(endInclusive) || t.Equal(endInclusive)
 	return afterStart && beforeOrEqualToEnd
 }
 
-// BetweenExclusive will return true if this dynamocity.Time is after the start and before to the end
-func (t Time) BetweenExclusive(startExclusive, endExclusive Time) bool {
-	afterStart := t.Time().After(startExclusive.Time())
-	beforeEnd := t.Time().Before(endExclusive.Time())
+// BetweenExclusive will return true if this dynamocity.MillisTime is after the start and before to the end
+func BetweenExclusive(t, startExclusive, endExclusive time.Time) bool {
+	afterStart := t.After(startExclusive)
+	beforeEnd := t.Before(endExclusive)
 	return afterStart && beforeEnd
 }
 
-// BetweenInclusive will return true if this dynamocity.Time is after or equal to the start and before or equal to the end
-func (t Time) BetweenInclusive(start, end Time) bool {
-	afterOrEqualToStart := t.Time().After(start.Time()) || t.Time().Equal(start.Time())
-	beforeOrEqualToEnd := t.Time().Before(end.Time()) || t.Time().Equal(end.Time())
+// BetweenInclusive will return true if this dynamocity.MillisTime is after or equal to the start and before or equal to the end
+func BetweenInclusive(t, start, end time.Time) bool {
+	afterOrEqualToStart := t.After(start) || t.Equal(start)
+	beforeOrEqualToEnd := t.Before(end) || t.Equal(end)
 	return afterOrEqualToStart && beforeOrEqualToEnd
-}
-
-// String implements the fmt.Stringer interface to supply a native String representation for a value in RFC3339
-// Format with nanosecond precision
-func (t Time) String() string {
-	return t.Time().Format(StrictNanoMarshallingFmt)
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface to marshal RFC3339 timestamps with nanosecond precision
-func (t *Time) UnmarshalJSON(b []byte) error {
-	str, err := strconv.Unquote(string(b))
-	if err != nil {
-		return err
-	}
-	parsedTime, err := time.Parse(FlexibleNanoUnmarshallingFmt, str)
-	if err != nil {
-		return err
-	}
-	*t = Time(parsedTime)
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaler interface to marshal RFC3339 timestamps with nanosecond precision
-func (t Time) MarshalJSON() ([]byte, error) {
-	return []byte(strconv.Quote(t.String())), nil
 }


### PR DESCRIPTION
* Adds MillisTime which provides millisecond precision when marshalling
to JSON or a Dynamo String attribute
* Adds SecondsTime which provides Seconds precision when marshalling
to JSON or a Dynamo String attribute
* Renames dynamocity.Time -> dynamocity.NanoTime
* Updates the time comparison functions to be more generic to accept
time.Time types.